### PR TITLE
Updated to correct groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.fenlisproject.hashtagedittext:library:1.0.0'
+    implementation 'HashTagEditText:library:1.0.0'
 }
 ```
 


### PR DESCRIPTION
This package groupId is incorrect in the [JCenter listing](https://bintray.com/fenli/maven/HashTagEditText) and so it does not import. When I change the groupId to com.fenlisproject.hashtagedittext to HashTagEditText it works and gets imported.